### PR TITLE
remove 'all' option from run_names, warn if provdied run names are no…

### DIFF
--- a/swc_ephys/pipeline/full_pipeline.py
+++ b/swc_ephys/pipeline/full_pipeline.py
@@ -41,8 +41,7 @@ def run_full_pipeline(
 
     run_names : Union[List[str], str],
         The spikeglx run name (i.e. not including the gate index). This can
-        also be a list of run names, or "all", in which case all runs in that
-        folder will be concatenated and sorted together. Preprocessing
+        also be a list of run names. Preprocessing
         will still occur per-run. Runs will always be concatenated in date
         order.
 

--- a/swc_ephys/pipeline/load_data.py
+++ b/swc_ephys/pipeline/load_data.py
@@ -31,7 +31,7 @@ def load_spikeglx_data(
 
     run_names : Union[List[str], str],
         The spikeglx run name (i.e. not including the gate index). This can
-        also be a list of run names, or "all".
+        also be a list of run names.
 
     Returns
     -------

--- a/swc_ephys/pipeline/sort.py
+++ b/swc_ephys/pipeline/sort.py
@@ -203,7 +203,7 @@ def validate_inputs(
 
 def get_singularity_image(sorter: str) -> Union[Literal[True], str]:
     """
-    Get the path to a pre-installed system sginuarlity image. If none
+    Get the path to a pre-installed system singularity image. If none
     can be found, set to True. In this case SpikeInterface will
     pull the imagine to the current working directory, and
     this will be moved after sorting

--- a/swc_ephys/utils/utils.py
+++ b/swc_ephys/utils/utils.py
@@ -226,9 +226,9 @@ def sort_list_of_paths_by_datetime_order(list_of_paths: List[Path]) -> List[Path
     return list_of_paths_by_creation_time
 
 
-def assert_list_of_files_are_in_datetime_order(
+def list_of_files_are_in_datetime_order(
     list_of_paths: List[Path], creation_or_modification: str = "creation"
-) -> None:
+) -> bool:
     """
     Assert whether a list of paths are in order. By default, check they are
     in order by creation date. Can also check if they are ordered by
@@ -254,14 +254,10 @@ def assert_list_of_files_are_in_datetime_order(
         os.path.getmtime if creation_or_modification == "creation" else os.path.getctime
     )
 
-    list_of_paths_by_mod_time = copy.deepcopy(list_of_paths)
-    list_of_paths_by_mod_time.sort(key=filter)
+    list_of_paths_by_time = copy.deepcopy(list_of_paths)
+    list_of_paths_by_time.sort(key=filter)
 
-    assert list_of_paths == list_of_paths_by_mod_time, (
-        f"Run list of files are not in {creation_or_modification} datetime order. "
-        f"Files List: {list_of_paths}\n"
-        f"Please get in contact if you wish to analyse out of datetime order."
-    )
+    return list_of_paths == list_of_paths_by_time
 
 
 def make_preprocessing_plot_title(


### PR DESCRIPTION
It was confusing that "all" to select all runs for a subject could be used but not robustly sorted by creation date. Now users must explicitly pass the runs they want in order, and a warning will be shown if this is not datetime order.