### PR TITLE
Expand postprocessing

### DIFF
--- a/swc_ephys/data_classes/sorting.py
+++ b/swc_ephys/data_classes/sorting.py
@@ -58,6 +58,7 @@ class SortingData(BaseUserDict):
         self.sorter_run_output_path = Path()
         self.waveforms_output_path = Path()
         self.quality_metrics_path = Path()
+        self.unit_locations_path = Path()
 
         # This is set later, depending on
         # concatenated or not.
@@ -155,3 +156,4 @@ class SortingData(BaseUserDict):
         self.sorter_run_output_path = self.sorter_base_output_path / "sorter_output"
         self.waveforms_output_path = self.sorter_base_output_path / "waveforms"
         self.quality_metrics_path = self.sorter_base_output_path / "quality_metrics.csv"
+        self.unit_locations_path = self.sorter_base_output_path / "unit_locations.csv"

--- a/swc_ephys/examples/example_quality.py
+++ b/swc_ephys/examples/example_quality.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from swc_ephys.pipeline.quality import quality_check
+from swc_ephys.pipeline.postprocess import run_postprocess
 
 base_path = Path(
     Path(r"/ceph/neuroinformatics/neuroinformatics/scratch/ece_ephys_learning")
@@ -11,4 +11,4 @@ run_name = "1110925_test_shank1_cut"
 
 output_path = base_path / "derivatives" / sub_name / f"{run_name}" / "preprocessed"
 
-quality_check(output_path, sorter="kilosort2_5")
+run_postprocess(output_path, sorter="kilosort2_5")

--- a/swc_ephys/pipeline/full_pipeline.py
+++ b/swc_ephys/pipeline/full_pipeline.py
@@ -11,7 +11,7 @@ from ..configs.configs import get_configs
 from ..utils import slurm, utils
 from .load_data import load_spikeglx_data
 from .preprocess import preprocess
-from .quality import quality_check
+from .postprocess import run_postprocess
 from .sort import run_sorting
 
 
@@ -29,7 +29,7 @@ def run_full_pipeline(
     slurm_batch: bool = False,
 ) -> None:
     """
-    Run preprocessing, sorting and quality checks on SpikeGLX data.
+    Run preprocessing, sorting and post-processing on SpikeGLX data.
     see README.md for detailed information on use.
 
     This function must be run in main as uses multiprocessing e.g.
@@ -102,11 +102,11 @@ def run_full_pipeline(
         overwrite_existing_sorter_output,
         verbose,
     )
-
+    # TODO: update this doc.
     # Save spikeinterface 'waveforms' output (TODO: currently, this is large)
     # to the sorter output dir. Quality checks are run and .csv of checks
     # output in the sorter folder as quality_metrics.csv
-    quality_check(sorting_data.preprocessed_data_path, sorter, verbose)
+    run_postprocess(sorting_data.preprocessed_data_path, sorter, verbose)
 
 
 def save_preprocessed_data_if_required(

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -79,7 +79,6 @@ def run_postprocess(
     quality_metrics = si.qualitymetrics.compute_quality_metrics(waveforms)
     quality_metrics.to_csv(sorting_data.quality_metrics_path)
 
-    # TODO: expose unit locations method (defalt centre of mass)
     unit_locations = si.postprocessing.compute_unit_locations(waveforms, outputs="by_unit")
     unit_locations_pandas = pd.DataFrame.from_dict(unit_locations, orient="index", columns=["x", "y"])
     unit_locations_pandas.to_csv(sorting_data.unit_locations_path)

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -19,13 +19,14 @@ from ..pipeline.load_data import load_data_for_sorting
 from ..utils import utils
 
 
-def quality_check(
+def run_postprocess(
     sorting_data: Union[Path, str, SortingData],
     sorter: str = "kilosort2_5",
     verbose: bool = True,
 ) -> None:
     """
-    Save quality metrics on sorting output to a quality_metrics.csv file.
+    Run post-processing, including ave quality metrics on sorting
+    output to a quality_metrics.csv file.
 
     Parameters
     ----------

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 
 from pathlib import Path
+import pandas as pd
 
 import spikeinterface as si
 from spikeinterface import curation
@@ -75,10 +76,16 @@ def run_postprocess(
 
         waveforms = si.load_waveforms(sorting_data.waveforms_output_path)
 
-    metrics = si.qualitymetrics.compute_quality_metrics(waveforms)
-    metrics.to_csv(sorting_data.quality_metrics_path)
+    quality_metrics = si.qualitymetrics.compute_quality_metrics(waveforms)
+    quality_metrics.to_csv(sorting_data.quality_metrics_path)
+
+    # TODO: expose unit locations method (defalt centre of mass)
+    unit_locations = si.postprocessing.compute_unit_locations(waveforms, outputs="by_unit")
+    unit_locations_pandas = pd.DataFrame.from_dict(unit_locations, orient="index", columns=["x", "y"])
+    unit_locations_pandas.to_csv(sorting_data.unit_locations_path)
 
     utils.message_user(f"Quality metrics saved to {sorting_data.quality_metrics_path}")
+    utils.message_user(f"Unit locations saved to {sorting_data.unit_locations_path}")
 
 
 def load_sorting_output(sorting_data: SortingData, sorter: str) -> BaseSorting:

--- a/tests/test_integration/test_initial.py
+++ b/tests/test_integration/test_initial.py
@@ -9,7 +9,7 @@ import pytest
 
 from swc_ephys.pipeline import full_pipeline
 
-ON_HPC = False
+ON_HPC = True
 
 
 class TestFirstEphys:
@@ -108,7 +108,7 @@ class TestFirstEphys:
 
         with open(slurm_run, "r") as log:
             log_output = log.readlines()
-
+        breakpoint()
         assert "Stopping container" in log_output
         assert "Saving waveforms to" in log_output
         assert "Quality metrics saved to" in log_output


### PR DESCRIPTION
Change quality-metrics to post-processing, adding also the centre-of-mass output for each cluster. The postprocessing module can now be extended when additional metrics are required.