### PR TITLE
Pin spikeinterface version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "spikeinterface[full] @git+https://github.com/SpikeInterface/spikeinterface",
+    "spikeinterface==0.97.1",
+    # "spikeinterface[full] @git+https://github.com/SpikeInterface/spikeinterface",
     "spython",  # I think missing from SI?
     "submitit",
 ]


### PR DESCRIPTION
Pin SI to 0.97.1 to avoid breaking changes in new versions.