### PR TITLE
Expose sparisty as waveform setting

### DIFF
--- a/swc_ephys/configs/test.yaml
+++ b/swc_ephys/configs/test.yaml
@@ -27,3 +27,8 @@
   'ms_after': 2
   'max_spikes_per_unit': 500
   'return_scaled': True
+  # Sparsity Options
+  'sparse': True
+  'peak_sign': "neg"
+  'method': "radius"
+  'radius_um': 75


### PR DESCRIPTION
In SpikeInterface, waveforms (i.e. individual action potentials that have been assigned to a unit) can be isolated and indexed out of the timeseries, using the WaveformExtractor class.

By default, they will store as num_waveforms x num_samples x num_channels matrix (including all recording channels). In practice however, only a subset of the channels are meaningful and actually record the action potential. As such, SpikeInterface provies a number of ways to reduce the number of channels waveforms are extracted on. 

This is important downstream, for example for averaging over all channels to create template waveforms. This PR removes channel selection from lower-level functions and exposes it as a top-level setting that the user can adjust. This makes it explicit which channels are being used for generating the templates and make use more intuitive.

These settings will have to be very very well documented as they are slightly obsure for the begginer. 