### PR TITLE
Add handle existing sorting and postprocessing options

### DIFF
--- a/swc_ephys/data_classes/preprocessing.py
+++ b/swc_ephys/data_classes/preprocessing.py
@@ -202,6 +202,11 @@ class PreprocessingData(BaseUserDict):
 
         return pp_run_name
 
+    def get_expected_sorter_path(self, sorter: str) -> Path:
+        return utils.make_sorter_base_output_path(
+            self.base_path, self.sub_name, self.pp_run_name, sorter
+        )
+
     # Load and Save --------------------------------------------------------------------
 
     def set_pp_steps(self, pp_steps: Dict) -> None:

--- a/swc_ephys/data_classes/sorting.py
+++ b/swc_ephys/data_classes/sorting.py
@@ -56,7 +56,7 @@ class SortingData(BaseUserDict):
         # is known, set_sorter_output_paths()
         self.sorter_base_output_path = Path()
         self.sorter_run_output_path = Path()
-        self.waveforms_output_path = Path()
+        self.postprocessing_output_path = Path()
         self.quality_metrics_path = Path()
         self.unit_locations_path = Path()
 
@@ -151,6 +151,12 @@ class SortingData(BaseUserDict):
 
         self.sorting_output_path = self.sorter_base_output_path / "sorting"
         self.sorter_run_output_path = self.sorting_output_path / "sorter_output"
-        self.waveforms_output_path = self.sorter_base_output_path / "postprocessing"
-        self.quality_metrics_path = self.waveforms_output_path / "quality_metrics.csv"
-        self.unit_locations_path = self.waveforms_output_path / "unit_locations.csv"
+        self.postprocessing_output_path = (
+            self.sorter_base_output_path / "postprocessing"
+        )
+        self.quality_metrics_path = (
+            self.postprocessing_output_path / "quality_metrics.csv"
+        )
+        self.unit_locations_path = (
+            self.postprocessing_output_path / "unit_locations.csv"
+        )

--- a/swc_ephys/data_classes/sorting.py
+++ b/swc_ephys/data_classes/sorting.py
@@ -145,12 +145,8 @@ class SortingData(BaseUserDict):
             canonical name, is where spikeinterface
             automatically saves sorter output
         """
-        self.sorter_base_output_path = (
-            self.base_path
-            / "derivatives"
-            / self.sub_name
-            / f"{self.pp_run_name}"
-            / f"{sorter}-sorting"
+        self.sorter_base_output_path = utils.make_sorter_base_output_path(
+            self.base_path, self.sub_name, self.pp_run_name, sorter
         )
 
         self.sorter_run_output_path = self.sorter_base_output_path / "sorter_output"

--- a/swc_ephys/data_classes/sorting.py
+++ b/swc_ephys/data_classes/sorting.py
@@ -149,7 +149,8 @@ class SortingData(BaseUserDict):
             self.base_path, self.sub_name, self.pp_run_name, sorter
         )
 
-        self.sorter_run_output_path = self.sorter_base_output_path / "sorter_output"
-        self.waveforms_output_path = self.sorter_base_output_path / "waveforms"
-        self.quality_metrics_path = self.sorter_base_output_path / "quality_metrics.csv"
-        self.unit_locations_path = self.sorter_base_output_path / "unit_locations.csv"
+        self.sorting_output_path = self.sorter_base_output_path / "sorting"
+        self.sorter_run_output_path = self.sorting_output_path / "sorter_output"
+        self.waveforms_output_path = self.sorter_base_output_path / "postprocessing"
+        self.quality_metrics_path = self.waveforms_output_path / "quality_metrics.csv"
+        self.unit_locations_path = self.waveforms_output_path / "unit_locations.csv"

--- a/swc_ephys/examples/example_full_pipeline.py
+++ b/swc_ephys/examples/example_full_pipeline.py
@@ -4,7 +4,7 @@ from swc_ephys.pipeline.full_pipeline import run_full_pipeline
 
 base_path = Path(
     r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617"
-    r"/time-mid"
+    r"/time-short"
 )
 sub_name = "1119617"
 run_names = [
@@ -24,6 +24,7 @@ if __name__ == "__main__":
         config_name,
         sorter,
         existing_preprocessed_data="load_if_exists",
-        overwrite_existing_sorter_output=True,
+        existing_sorting_output="load_if_exists",
+        overwrite_postprocessing=True,
         slurm_batch=False,
     )

--- a/swc_ephys/examples/example_full_pipeline.py
+++ b/swc_ephys/examples/example_full_pipeline.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         config_name,
         sorter,
         existing_preprocessed_data="load_if_exists",
-        existing_sorting_output="load_if_exists",
+        existing_sorting_output="overwrite",
         overwrite_postprocessing=True,
         slurm_batch=False,
     )

--- a/swc_ephys/examples/example_postprocess.py
+++ b/swc_ephys/examples/example_postprocess.py
@@ -17,5 +17,4 @@ run_postprocess(
     preprocessing_path,
     sorter="kilosort2_5",
     existing_waveform_data="overwrite",
-    postprocessing_to_run="all",
 )

--- a/swc_ephys/examples/example_postprocess.py
+++ b/swc_ephys/examples/example_postprocess.py
@@ -3,14 +3,16 @@ from pathlib import Path
 from swc_ephys.pipeline.postprocess import run_postprocess
 
 base_path = Path(
-    r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-mid"
+    r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
 )
 # TODO: why is this taking the preprocessed path? isn't sorting more intuitive? or top level? think...
 sub_name = "1119617"
 run_name = "1119617_LSE1_shank12_posttest1_pretest1"
 
-output_path = (
+preprocessing_path = (
     base_path / "derivatives" / sub_name / f"{run_name}" / "preprocessed"
-)  # This is the most stupidly named variable of all time. This is INPUT preprocessing.
+)
 
-run_postprocess(output_path, sorter="kilosort2_5")
+run_postprocess(
+    preprocessing_path, sorter="kilosort2_5", existing_waveform_data="load_if_exists"
+)

--- a/swc_ephys/examples/example_postprocess.py
+++ b/swc_ephys/examples/example_postprocess.py
@@ -14,5 +14,13 @@ preprocessing_path = (
 )
 
 run_postprocess(
-    preprocessing_path, sorter="kilosort2_5", existing_waveform_data="load_if_exists"
+    preprocessing_path,
+    sorter="kilosort2_5",
+    existing_waveform_data="load_if_exists",
+    postprocessing_to_run={
+        "quality_metrics": False,
+        "waveform_similarity": False,
+        "unit_locations": True,
+        "template_plots": True,
+    },
 )

--- a/swc_ephys/examples/example_postprocess.py
+++ b/swc_ephys/examples/example_postprocess.py
@@ -3,9 +3,7 @@ from pathlib import Path
 from swc_ephys.pipeline.postprocess import run_postprocess
 
 base_path = Path(
-    Path(
-        r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-mid"
-    )
+    r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-mid"
 )
 # TODO: why is this taking the preprocessed path? isn't sorting more intuitive? or top level? think...
 sub_name = "1119617"

--- a/swc_ephys/examples/example_postprocess.py
+++ b/swc_ephys/examples/example_postprocess.py
@@ -16,11 +16,6 @@ preprocessing_path = (
 run_postprocess(
     preprocessing_path,
     sorter="kilosort2_5",
-    existing_waveform_data="load_if_exists",
-    postprocessing_to_run={
-        "quality_metrics": False,
-        "waveform_similarity": False,
-        "unit_locations": True,
-        "template_plots": True,
-    },
+    existing_waveform_data="overwrite",
+    postprocessing_to_run="all",
 )

--- a/swc_ephys/examples/example_sort.py
+++ b/swc_ephys/examples/example_sort.py
@@ -1,25 +1,24 @@
 from pathlib import Path
 
-from swc_ephys.pipeline.load_data import load_spikeglx_data
-from swc_ephys.pipeline.preprocess import preprocess
 from swc_ephys.pipeline.sort import run_sorting
 
 base_path = Path(
-    "/ceph/neuroinformatics/neuroinformatics/scratch/steve_multi_run/1119617/first_attempt/time-short_samenaming"
+    r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-mid"
 )
-sub_name = "cut_same_name"
-run_names = "all"
+sub_name = "1119617"
+run_name = "1119617_LSE1_shank12_posttest1_pretest1"
 
-preprocess_data = load_spikeglx_data(base_path, sub_name, run_names)
+preprocessed_data_path = (
+    base_path / "derivatives" / sub_name / f"{run_name}" / "preprocessed"
+)
 
-preprocess_data = preprocess(preprocess_data)
 
 if __name__ == "__main__":
     # sorting uses multiprocessing so must be in __main__
     run_sorting(
-        preprocess_data.preprocessed_data_path,
+        preprocessed_data_path,
         sorter="kilosort2_5",
         sorter_options={"kilosort2_5": {"car": False}},
-        overwrite_existing_sorter_output=True,
+        overwrite_existing_sorter_output=False,
         slurm_batch=False,
     )

--- a/swc_ephys/pipeline/full_pipeline.py
+++ b/swc_ephys/pipeline/full_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Literal, Union
 
@@ -8,6 +9,7 @@ if TYPE_CHECKING:
     from ..data_classes.preprocessing import PreprocessingData
 
 from ..configs.configs import get_configs
+from ..pipeline.load_data import load_data_for_sorting
 from ..utils import slurm, utils
 from .load_data import load_spikeglx_data
 from .postprocess import run_postprocess
@@ -23,16 +25,18 @@ def run_full_pipeline(
     run_names: Union[List[str], str],
     config_name: str = "test",
     sorter: str = "kilosort2_5",
-    existing_preprocessed_data: HandleExisting = "overwrite",
-    existing_sorting_output: HandleExisting = "overwrite",
-    existing_waveform_data: HandleExisting = "overwrite",
+    existing_preprocessed_data: HandleExisting = "load_if_exists",
+    existing_sorting_output: HandleExisting = "load_if_exists",
+    overwrite_postprocessing: bool = False,
     postprocessing_to_run: Union[Literal["all"], Dict] = "all",
     verbose: bool = True,
     slurm_batch: bool = False,
 ) -> None:
     """
     Run preprocessing, sorting and post-processing on SpikeGLX data.
-    see README.md for detailed information on use.
+    see README.md for detailed information on use. If waveforms and
+    postprocessing exist for the subjects / runs, it will be
+    overwritten.
 
     This function must be run in main as uses multiprocessing e.g.
     if __name__ == "__main__":
@@ -60,20 +64,29 @@ def run_full_pipeline(
     sorter : str
         name of the sorter to use e.g. "kilosort2_5".
 
-    existing_preprocessed_data : Literal[
-                                 "overwrite", "load_if_exists", "fail_if_exists"]
+    existing_preprocessed_data : Literal["overwrite", "load_if_exists", "fail_if_exists"]
         Determines how existing preprocessed data (e.g. from a prior pipeline run)
         is treated.
-            "overwrite" : will overwrite any existing preprocessed data output.
+            "overwrite" : will overwrite any existing preprocessed data output. This will
+                          delete the 'preprocessed' folder. Therefore, never save
+                          derivative work there.
             "load_if_exists" : will search for existing data and load if it exists.
                                Otherwise, will use the preprocessing from the
                                current run.
             "fail_if_exists" : If existing preprocessed data is found, an error
                                will be raised.
 
-     existing_sorting_output : bool
-         If `False` an error will be raised if sorting output already
-         exists. If True, existing sorting output will be overwritten.
+    existing_sorting_output : bool
+        Determines how existing sorted data is treated. The same behaviour
+        as `existing_preprocessed_data` but for sorting output. If overwrite,
+        the 'sorting' folder will be deleted. Therefore, never save
+        derivative work there.
+
+    overwrite_postprocessing : bool
+        If `False`, an error will be raised if postprocessing output already
+        exists. Otherwise, 'postprocessing' folder will be overwritten. Note,
+        that the entire 'postprocessing' folder (including all contents) will be
+        deleted. Therefore, never save derivative work there.
 
     verbose : bool
         If True, messages will be printed to console updating on the
@@ -97,7 +110,12 @@ def run_full_pipeline(
 
     save_preprocessed_data_if_required(preprocess_data, existing_preprocessed_data)
 
-    sorting_data = run_or_get_sorting(preprocess_data, existing_sorting_output, sorter)
+    sorting_data = run_or_get_sorting(
+        preprocess_data, existing_sorting_output, sorter, sorter_options, verbose
+    )
+
+    sorting_data.set_sorter_output_paths(sorter)
+    delete_waveform_output_if_it_exists(sorting_data, overwrite_postprocessing)
 
     run_postprocess(
         sorting_data,
@@ -107,22 +125,47 @@ def run_full_pipeline(
     )
 
 
-def run_or_get_sorting(preprocess_data, existing_sorting_output, sorter):
-    """ """
-    sorting_path = preprocess_data.get_expected_sorter_path(sorter)
+def delete_waveform_output_if_it_exists(sorting_data, overwrite_postprocessing):
+    if sorting_data.waveforms_output_path.is_dir():
+        if overwrite_postprocessing:
+            utils.message_user(
+                f"Deleting existing postprocessing "
+                f"output at {sorting_data.waveforms_output_path}"
+            )
+            shutil.rmtree(sorting_data.waveforms_output_path)
+        else:
+            raise RuntimeError(
+                f"Postprocessing output already exists at {sorting_data.waveforms_output_path} "
+                f"but `overwrite_postprocessing` is `False`. Setting `overwrite_postprocessing` will "
+                f"delete the postprocessing folder and all it's contents."
+            )
 
-    if existing_sorting_output == "load_if_exists" and sorting_path.is_dir():
+
+def run_or_get_sorting(
+    preprocess_data, existing_sorting_output, sorter, sorter_options, verbose
+):
+    """ """
+    # TODO: "sorting" to configs.
+    sorting_path = preprocess_data.get_expected_sorter_path(sorter) / "sorting"
+
+    if sorting_path.is_dir() and existing_sorting_output == "load_if_exists":
         utils.message_user(f"Loaded pre-existing sorting output from {sorting_path}")
 
         sorting_data = load_data_for_sorting(
-            sorting_data,
+            preprocess_data.preprocessed_data_path,
         )
+
+    elif sorting_path.is_dir() and existing_sorting_output == "fail_if_exists":
+        raise RuntimeError(
+            f"Sorting output already exists at {sorting_path} and"
+            f"`existing_sorting_output` is set to 'fail_if_exists'."
+        )
+
     else:
         utils.message_user("Running sorting...")
 
-        overwrite_existing_sorter_output = (
-            True if existing_sorting_output == "overwrite" else False
-        )
+        overwrite_existing_sorter_output = True
+
         sorting_data = run_sorting(
             preprocess_data.preprocessed_data_path,
             sorter,

--- a/swc_ephys/pipeline/full_pipeline.py
+++ b/swc_ephys/pipeline/full_pipeline.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING, Dict, List, Literal, Union
 
 if TYPE_CHECKING:
     from ..data_classes.preprocessing import PreprocessingData
+    from ..data_classes.sorting import SortingData
 
 from ..configs.configs import get_configs
 from ..pipeline.load_data import load_data_for_sorting
 from ..utils import slurm, utils
-from ..utils.custom_typing import HandleExisting
+from ..utils.custom_types import HandleExisting
 from .load_data import load_spikeglx_data
 from .postprocess import run_postprocess
 from .preprocess import preprocess
@@ -87,6 +88,11 @@ def run_full_pipeline(
         that the entire 'postprocessing' folder (including all contents) will be
         deleted. Therefore, never save derivative work there.
 
+    postprocessing_to_run : Union[Literal["all"], Dict]
+        Specify the postprocessing to run. By default, "all" will run
+        all available postprocessing. Otherwise, provide a dict of
+        including postprocessing to run e.g. {"quality_metrics: True"}.
+
     verbose : bool
         If True, messages will be printed to console updating on the
         progress of preprocessing / sorting.
@@ -114,38 +120,57 @@ def run_full_pipeline(
     )
 
     sorting_data.set_sorter_output_paths(sorter)
-    delete_waveform_output_if_it_exists(sorting_data, overwrite_postprocessing)
+    delete_postprocessing_output_if_it_exists(sorting_data, overwrite_postprocessing)
 
     run_postprocess(
         sorting_data,
         sorter,
-        verbose,
-        waveform_options=waveform_options,
+        existing_waveform_data="fail_if_exists",
         postprocessing_to_run=postprocessing_to_run,
+        verbose=verbose,
+        waveform_options=waveform_options,
     )
 
 
-def delete_waveform_output_if_it_exists(sorting_data, overwrite_postprocessing):
-    if sorting_data.waveforms_output_path.is_dir():
+def delete_postprocessing_output_if_it_exists(
+    sorting_data: SortingData, overwrite_postprocessing: bool
+):
+    """
+    If previous postprocessing output exists, it must be deleted before
+    the new postprocessing is run. As a safety measure, `overwrite_postprocessing`
+    must be set to `True` to perform the deletion.
+    """
+    if sorting_data.postprocessing_output_path.is_dir():
         if overwrite_postprocessing:
             utils.message_user(
                 f"Deleting existing postprocessing "
-                f"output at {sorting_data.waveforms_output_path}"
+                f"output at {sorting_data.postprocessing_output_path}"
             )
-            shutil.rmtree(sorting_data.waveforms_output_path)
+            shutil.rmtree(sorting_data.postprocessing_output_path)
         else:
             raise RuntimeError(
-                f"Postprocessing output already exists at {sorting_data.waveforms_output_path} "
-                f"but `overwrite_postprocessing` is `False`. Setting `overwrite_postprocessing` will "
-                f"delete the postprocessing folder and all it's contents."
+                f"Postprocessing output already exists at "
+                f"{sorting_data.postprocessing_output_path} "
+                f"but `overwrite_postprocessing` is `False`. Setting "
+                f"`overwrite_postprocessing` will delete the postprocessing "
+                f"folder and all it's contents."
             )
 
 
 def run_or_get_sorting(
-    preprocess_data, existing_sorting_output, sorter, sorter_options, verbose
-):
-    """ """
-    # TODO: "sorting" to configs.
+    preprocess_data: PreprocessingData,
+    existing_sorting_output: HandleExisting,
+    sorter: str,
+    sorter_options: Dict,
+    verbose: bool,
+) -> SortingData:
+    """
+    Handle existing sorting output. If previous output exists, load, error or
+    overwrite according to `existing_sorting_output`. See `run_full_pipeline()` for details.
+    """
+    # TODO: "sorting" to configs. In general handle this function better
+    # it should not be on preprocess_data. It could be a classmethod on
+    # SortingData but this may be even messier.
     sorting_path = preprocess_data.get_expected_sorter_path(sorter) / "sorting"
 
     if sorting_path.is_dir() and existing_sorting_output == "load_if_exists":

--- a/swc_ephys/pipeline/full_pipeline.py
+++ b/swc_ephys/pipeline/full_pipeline.py
@@ -122,6 +122,7 @@ def run_full_pipeline(
         sorter,
         verbose,
         waveform_options=waveform_options,
+        postprocessing_to_run=postprocessing_to_run,
     )
 
 

--- a/swc_ephys/pipeline/full_pipeline.py
+++ b/swc_ephys/pipeline/full_pipeline.py
@@ -11,12 +11,11 @@ if TYPE_CHECKING:
 from ..configs.configs import get_configs
 from ..pipeline.load_data import load_data_for_sorting
 from ..utils import slurm, utils
+from ..utils.custom_typing import HandleExisting
 from .load_data import load_spikeglx_data
 from .postprocess import run_postprocess
 from .preprocess import preprocess
 from .sort import run_sorting
-
-HandleExisting = Literal["overwrite", "load_if_exists", "fail_if_exists"]
 
 
 def run_full_pipeline(

--- a/swc_ephys/pipeline/full_pipeline.py
+++ b/swc_ephys/pipeline/full_pipeline.py
@@ -28,7 +28,6 @@ def run_full_pipeline(
     existing_preprocessed_data: HandleExisting = "load_if_exists",
     existing_sorting_output: HandleExisting = "load_if_exists",
     overwrite_postprocessing: bool = False,
-    postprocessing_to_run: Union[Literal["all"], Dict] = "all",
     verbose: bool = True,
     slurm_batch: bool = False,
 ) -> None:
@@ -88,11 +87,6 @@ def run_full_pipeline(
         that the entire 'postprocessing' folder (including all contents) will be
         deleted. Therefore, never save derivative work there.
 
-    postprocessing_to_run : Union[Literal["all"], Dict]
-        Specify the postprocessing to run. By default, "all" will run
-        all available postprocessing. Otherwise, provide a dict of
-        including postprocessing to run e.g. {"quality_metrics: True"}.
-
     verbose : bool
         If True, messages will be printed to console updating on the
         progress of preprocessing / sorting.
@@ -126,7 +120,6 @@ def run_full_pipeline(
         sorting_data,
         sorter,
         existing_waveform_data="fail_if_exists",
-        postprocessing_to_run=postprocessing_to_run,
         verbose=verbose,
         waveform_options=waveform_options,
     )

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -17,14 +17,12 @@ from ..configs.configs import get_configs
 from ..data_classes.sorting import SortingData
 from ..pipeline.load_data import load_data_for_sorting
 from ..utils import utils
+from ..utils.custom_typing import HandleExisting
 from .waveform_compare import get_waveform_similarity
 
 if TYPE_CHECKING:
     from spikeinterface import WaveformExtractor
     from spikeinterface.core import BaseSorting
-
-# TODO REMOVE DUPLICATION!!
-HandleExisting = Literal["overwrite", "load_if_exists", "fail_if_exists"]
 
 MATRIX_BACKEND: Literal["numpy", "jax"]
 try:

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -45,7 +45,6 @@ def run_postprocess(
     sorting_data: Union[Path, str, SortingData],
     sorter: str,
     existing_waveform_data: HandleExisting = "load_if_exists",
-    postprocessing_to_run: Union[Literal["all"], Dict] = "all",
     verbose: bool = True,
     waveform_options: Optional[Dict] = None,
 ) -> None:
@@ -78,11 +77,6 @@ def run_postprocess(
             "fail_if_exists" : If existing preprocessed data is found, an error
                                will be raised.
 
-    postprocessing_to_run : Union[Literal["all"], Dict]
-        Specify the postprocessing to run. By default, "all" will run
-        all available postprocessing. Otherwise, provide a dict of
-        including postprocessing to run e.g. {"quality_metrics: True"}.
-
     verbose : bool
         If True, messages will be printed to console updating on the
         progress of preprocessing / sorting.
@@ -112,29 +106,15 @@ def run_postprocess(
         sorting_data, existing_waveform_data, waveform_options, sorter, verbose
     )
 
-    # Perform postprocessing
-    run_settings = handle_postprocessing_to_run(postprocessing_to_run)
-
-    if run_option(run_settings, "quality_metrics"):
-        save_quality_matrics(waveforms, sorting_data)
-
-    if run_option(run_settings, "unit_locations"):
-        save_unit_locations(waveforms, sorting_data)
-
-    if run_option(run_settings, "template_plots"):
-        save_plots_of_templates(sorting_data.postprocessing_output_path, waveforms)
-
-    if run_option(run_settings, "waveform_similarity"):
-        save_waveform_similarities(
-            sorting_data.postprocessing_output_path, waveforms, MATRIX_BACKEND
-        )
+    save_quality_matrics(waveforms, sorting_data)
+    save_unit_locations(waveforms, sorting_data)
+    save_plots_of_templates(sorting_data.postprocessing_output_path, waveforms)
+    save_waveform_similarities(
+        sorting_data.postprocessing_output_path, waveforms, MATRIX_BACKEND
+    )
 
 
 # Sorting Loader -----------------------------------------------------------------------
-
-
-def run_option(run_settings: Dict, option: str):
-    return option in run_settings and run_settings[option]
 
 
 def run_or_get_waveforms(
@@ -184,37 +164,6 @@ def run_or_get_waveforms(
         )
 
     return waveforms
-
-
-def handle_postprocessing_to_run(postprocessing_to_run: Union[Literal["all"], Dict]):
-    """
-    Set to run all postprocessing steps. If user-dict is provided,
-    ensure it contains expected keys / values.
-    """
-    run_settings = {
-        "quality_metrics": True,
-        "unit_locations": True,
-        "template_plots": True,
-        "waveform_similarity": True,
-    }
-
-    if postprocessing_to_run == "all":
-        return run_settings
-    else:
-        assert isinstance(postprocessing_to_run, Dict)
-        assert all(
-            [key in run_settings.keys() for key in postprocessing_to_run.keys()]
-        ), (
-            f"At least one option in `postprocessing_to_run` is invalid. Must be"
-            f"one of {run_settings.keys()}"
-        )
-        assert all(
-            [isinstance(value, bool) for value in postprocessing_to_run.values()]
-        ), "`postprocessing_to_run` values must be `True` or `False`."
-
-        run_settings = postprocessing_to_run
-
-        return run_settings
 
 
 def load_sorting_output(sorting_data: SortingData, sorter: str) -> BaseSorting:

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -17,7 +17,7 @@ from ..configs.configs import get_configs
 from ..data_classes.sorting import SortingData
 from ..pipeline.load_data import load_data_for_sorting
 from ..utils import utils
-from ..utils.custom_typing import HandleExisting
+from ..utils.custom_types import HandleExisting
 from .waveform_compare import get_waveform_similarity
 
 if TYPE_CHECKING:
@@ -66,6 +66,23 @@ def run_postprocess(
     sorter : str
         The name of the sorter (e.g. "kilosort2_5").
 
+    existing_waveform_data : Literal["overwrite", "load_if_exists", "fail_if_exists"]
+        Determines how existing preprocessed data (e.g. from a prior pipeline run)
+        is treated.
+            "overwrite" : will overwrite any existing preprocessed data output. This will
+                          delete the 'preprocessed' folder. Therefore, never save
+                          derivative work there.
+            "load_if_exists" : will search for existing data and load if it exists.
+                               Otherwise, will use the preprocessing from the
+                               current run.
+            "fail_if_exists" : If existing preprocessed data is found, an error
+                               will be raised.
+
+    postprocessing_to_run : Union[Literal["all"], Dict]
+        Specify the postprocessing to run. By default, "all" will run
+        all available postprocessing. Otherwise, provide a dict of
+        including postprocessing to run e.g. {"quality_metrics: True"}.
+
     verbose : bool
         If True, messages will be printed to console updating on the
         progress of preprocessing / sorting.
@@ -105,50 +122,62 @@ def run_postprocess(
         save_unit_locations(waveforms, sorting_data)
 
     if run_option(run_settings, "template_plots"):
-        save_plots_of_templates(sorting_data.waveforms_output_path, waveforms)
+        save_plots_of_templates(sorting_data.postprocessing_output_path, waveforms)
 
     if run_option(run_settings, "waveform_similarity"):
         save_waveform_similarities(
-            sorting_data.waveforms_output_path, waveforms, MATRIX_BACKEND
+            sorting_data.postprocessing_output_path, waveforms, MATRIX_BACKEND
         )
 
 
 # Sorting Loader -----------------------------------------------------------------------
 
 
-def run_option(run_settings, option):
+def run_option(run_settings: Dict, option: str):
     return option in run_settings and run_settings[option]
 
 
 def run_or_get_waveforms(
-    sorting_data, existing_waveform_data, waveform_options, sorter, verbose
+    sorting_data: SortingData,
+    existing_waveform_data: HandleExisting,
+    waveform_options: Dict,
+    sorter: str,
+    verbose: bool,
 ):
+    """
+    How to handle existing waveform output, either load, fail if exists or
+    overwrite.
+    """
     if (
-        sorting_data.waveforms_output_path.is_dir()
+        sorting_data.postprocessing_output_path.is_dir()
         and existing_waveform_data == "load_if_exists"
     ):
         utils.message_user(
-            f"Loading existing waveforms from: {sorting_data.waveforms_output_path}",
+            f"Loading existing waveforms from: "
+            f"{sorting_data.postprocessing_output_path}",
             verbose,
         )
-        waveforms = si.load_waveforms(sorting_data.waveforms_output_path)
+        waveforms = si.load_waveforms(sorting_data.postprocessing_output_path)
 
     elif (
-        sorting_data.waveforms_output_path.is_dir()
+        sorting_data.postprocessing_output_path.is_dir()
         and existing_waveform_data == "fail_if_exists"
     ):
         raise RuntimeError(
-            f"Waveforms exist at {sorting_data.waveforms_output_path} but `existing_waveform_data` is 'fail_if_exists'."
+            f"Waveforms exist at {sorting_data.postprocessing_output_path} but "
+            f"`existing_waveform_data` is 'fail_if_exists'."
         )
     else:
-        utils.message_user(f"Saving waveforms to {sorting_data.waveforms_output_path}")
+        utils.message_user(
+            f"Saving waveforms to {sorting_data.postprocessing_output_path}"
+        )
 
         sorting_without_excess_spikes = load_sorting_output(sorting_data, sorter)
 
         waveforms = si.extract_waveforms(
             sorting_data.data["0-preprocessed"],
             sorting_without_excess_spikes,
-            folder=sorting_data.waveforms_output_path,
+            folder=sorting_data.postprocessing_output_path,
             use_relative_path=True,
             overwrite=True,
             **waveform_options,
@@ -157,16 +186,22 @@ def run_or_get_waveforms(
     return waveforms
 
 
-def handle_postprocessing_to_run(postprocessing_to_run):
+def handle_postprocessing_to_run(postprocessing_to_run: Union[Literal["all"], Dict]):
+    """
+    Set to run all postprocessing steps. If user-dict is provided,
+    ensure it contains expected keys / values.
+    """
     run_settings = {
         "quality_metrics": True,
         "unit_locations": True,
         "template_plots": True,
         "waveform_similarity": True,
     }
+
     if postprocessing_to_run == "all":
         return run_settings
     else:
+        assert isinstance(postprocessing_to_run, Dict)
         assert all(
             [key in run_settings.keys() for key in postprocessing_to_run.keys()]
         ), (
@@ -261,7 +296,7 @@ def save_unit_locations(waveforms: WaveformExtractor, sorting_data: SortingData)
 
 
 def save_waveform_similarities(
-    waveforms_output_path: Path,
+    postprocessing_output_path: Path,
     waveforms: WaveformExtractor,
     backend: Literal["jax", "numpy"],
 ):
@@ -276,7 +311,7 @@ def save_waveform_similarities(
     Parameters
     ---------
 
-    waveforms_output_path : Path
+    postprocessing_output_path : Path
         Pathlib object holding the output path where waveforms are saved
         and /images will be written.
 
@@ -289,7 +324,7 @@ def save_waveform_similarities(
     """
     utils.message_user("Saving waveform similarity matrices...\n")
 
-    matrices_out_path = waveforms_output_path / "similarity_matrices"
+    matrices_out_path = postprocessing_output_path / "similarity_matrices"
     matrices_out_path.mkdir(exist_ok=True)
 
     t = time.perf_counter()
@@ -311,7 +346,9 @@ def save_waveform_similarities(
 # --------------------------------------------------------------------------------------
 
 
-def save_plots_of_templates(waveforms_output_path: Path, waveforms: WaveformExtractor):
+def save_plots_of_templates(
+    postprocessing_output_path: Path, waveforms: WaveformExtractor
+):
     """
     Save a plot of all templates in 'waveforms/images' folder. The plot
     displays the template waveform are calculated in two ways
@@ -328,7 +365,7 @@ def save_plots_of_templates(waveforms_output_path: Path, waveforms: WaveformExtr
     Parameters
     ------
 
-    waveforms_output_path : Path
+    postprocessing_output_path : Path
         Pathlib object holding the output path where waveforms are saved
         and /images will be written.
 
@@ -357,9 +394,11 @@ def save_plots_of_templates(waveforms_output_path: Path, waveforms: WaveformExtr
         plt.ylabel(y_label)
         plt.title(f"Unit {unit_id} Template")
 
-        output_folder = waveforms_output_path / "template_plots"
+        output_folder = postprocessing_output_path / "template_plots"
         output_folder.mkdir(exist_ok=True)
-        plt.savefig(waveforms_output_path / "template_plots" / f"unit_{unit_id}.png")
+        plt.savefig(
+            postprocessing_output_path / "template_plots" / f"unit_{unit_id}.png"
+        )
         plt.clf()
 
     utils.message_user(f"Saving plots of templates took: {time.perf_counter() - t}")

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -107,17 +107,50 @@ def run_postprocess(
         )
         waveforms = si.load_waveforms(sorting_data.waveforms_output_path)
 
-    save_plots_of_templates(sorting_data.waveforms_output_path, waveforms)
-
     # Perform postprocessing
-    save_quality_matrics(waveforms, sorting_data)
-    save_unit_locations(waveforms, sorting_data)
-    save_waveform_similarities(
-        sorting_data.waveforms_output_path, waveforms, MATRIX_BACKEND
-    )
+    postprocessing_to_run = "all"
+    run_settings = handle_postprocessing_to_run(postprocessing_to_run)
+
+    if run_settings["quality_metrics"]:
+        save_quality_matrics(waveforms, sorting_data)
+
+    if run_settings["unit_locations"]:
+        save_unit_locations(waveforms, sorting_data)
+
+    if run_settings["template_plots"]:
+        save_plots_of_templates(sorting_data.waveforms_output_path, waveforms)
+
+    if run_settings["waveform_similarity"]:
+        save_waveform_similarities(
+            sorting_data.waveforms_output_path, waveforms, MATRIX_BACKEND
+        )
 
 
 # Sorting Loader -----------------------------------------------------------------------
+
+
+def handle_postprocessing_to_run(postprocessing_to_run):
+    run_settings = {
+        "quality_metrics": True,
+        "unit_locations": True,
+        "template_plots": True,
+        "waveform_similarity": True,
+    }
+    if postprocessing_to_run == "all":
+        return run_settings
+    else:
+        assert all(
+            [key in run_settings.keys() for key in postprocessing_to_run.keys()]
+        ), (
+            f"At least one option in `postprocessing_to_run` is invalid. Must be"
+            f"one of {run_settings.keys()}"
+        )
+        assert all(
+            [isinstance(value, bool) for value in postprocessing_to_run.values()]
+        ), "`postprocessing_to_run` values must be `True` or `False`."
+
+        run_settings.update(postprocessing_to_run)
+        return run_settings
 
 
 def load_sorting_output(sorting_data: SortingData, sorter: str) -> BaseSorting:

--- a/swc_ephys/pipeline/preprocess.py
+++ b/swc_ephys/pipeline/preprocess.py
@@ -157,11 +157,11 @@ def perform_preprocessing_step(
         applied across the entire preprocessing chain.
 
     pp_funcs : Dict
-        The cannonical SpikeInterface preprocessing functions. The key
+        The canonical SpikeInterface preprocessing functions. The key
         are the function name and value the function object.
 
     verbose : bool
-        If True, messages will be printed to consolve updating on the
+        If True, messages will be printed to console updating on the
         progress of preprocessing / sorting.
     """
     pp_name, pp_options = pp_info

--- a/swc_ephys/pipeline/sort.py
+++ b/swc_ephys/pipeline/sort.py
@@ -84,7 +84,7 @@ def run_sorting(
     ss.run_sorter(
         sorter,
         sorting_data.data["0-preprocessed"],
-        output_folder=sorting_data.sorter_base_output_path,
+        output_folder=sorting_data.sorting_output_path,
         singularity_image=singularity_image,
         remove_existing_folder=overwrite_existing_sorter_output,
         **sorter_options_dict,

--- a/swc_ephys/pipeline/waveform_compare.py
+++ b/swc_ephys/pipeline/waveform_compare.py
@@ -44,7 +44,9 @@ def get_waveform_similarity(
     ), "Number of waveform peak times does not match number of extracted waveforms."
 
     if waveforms_data.shape[0] == 1:
-        utils.message_user("Skipping {unit_id} as one waveform detected for this unit.")
+        utils.message_user(
+            f"Skipping {unit_id} as one waveform detected for this unit."
+        )
         return np.nan, selected_waveform_peak_times
 
     if backend == "numpy":

--- a/swc_ephys/utils/custom_types.py
+++ b/swc_ephys/utils/custom_types.py
@@ -1,0 +1,3 @@
+from typing import Literal
+
+HandleExisting = Literal["overwrite", "load_if_exists", "fail_if_exists"]

--- a/swc_ephys/utils/utils.py
+++ b/swc_ephys/utils/utils.py
@@ -307,6 +307,16 @@ def list_of_files_are_in_datetime_order(
     return is_in_time_order
 
 
+def make_sorter_base_output_path(base_path, sub_name, pp_run_name, sorter):
+    """
+    Make the canonical sorter output path.
+    """
+    sorter_base_output_path = (
+        base_path / "derivatives" / sub_name / f"{pp_run_name}" / f"{sorter}-sorting"
+    )
+    return sorter_base_output_path
+
+
 def make_preprocessing_plot_title(
     run_name: str,
     full_key: str,


### PR DESCRIPTION
Extend the options in `run_full_pipeline()` and `run_postprocessing` that existing to handle existing postprocessing data (`load_if_exists`, `fail_if_exists` and `overwrite`) to sorting and postprocessing.

Further, `run_full_pipeline` will delete all existing postprocessing, requiring the override switch `overwrite_postprocessing`.

Some minor changes to sorting folder output are made to split sorting and postprocessing. 