### PR TITLE
Save sync channel

### DIFF
--- a/swc_ephys/data_classes/preprocessing.py
+++ b/swc_ephys/data_classes/preprocessing.py
@@ -65,10 +65,12 @@ class PreprocessingData(BaseUserDict):
 
         self.pp_steps: Optional[Dict] = None
         self.data: Dict = {"0-raw": None}
+        self.sync = None
 
         self.preprocessed_data_path = Path()
         self._pp_data_attributes_path = Path()
         self._pp_binary_data_path = Path()
+        self._sync_channel_data_path = Path()
         self._set_preprocessing_output_path()
 
     # Handle Multiple Runs -------------------------------------------------------------
@@ -244,6 +246,7 @@ class PreprocessingData(BaseUserDict):
                 shutil.rmtree(self.preprocessed_data_path)
         self._save_data_class()
         self._save_preprocessed_binary()
+        self._save_sync_channel()
 
     def _save_preprocessed_binary(self) -> None:
         """
@@ -252,6 +255,11 @@ class PreprocessingData(BaseUserDict):
         """
         recording, __ = utils.get_dict_value_from_step_num(self, "last")
         recording.save(folder=self._pp_binary_data_path, chunk_memory="10M")
+
+    def _save_sync_channel(self) -> None:
+        """ """
+        assert self.sync is not None, "Sync channel on PreprocessData is None"
+        self.sync.save(folder=self._sync_channel_data_path, chunk_memory="10M")
 
     def _save_data_class(self) -> None:
         """
@@ -271,6 +279,7 @@ class PreprocessingData(BaseUserDict):
             "preprocessed_data_path": self.preprocessed_data_path.as_posix(),
             "_pp_binary_data_path": self._pp_binary_data_path.as_posix(),
             "_pp_data_attributes_path": self._pp_data_attributes_path.as_posix(),
+            "_sync_channel_data_path": self._sync_channel_data_path.as_posix(),
         }
         if not self.preprocessed_data_path.is_dir():
             os.makedirs(self.preprocessed_data_path)
@@ -290,17 +299,17 @@ class PreprocessingData(BaseUserDict):
 
         TODO: move this to a canonical_filepaths module.
         """
-        self.preprocessed_data_path = (
-            self.base_path
-            / "derivatives"
-            / self.sub_name
-            / f"{self.pp_run_name}"
-            / "preprocessed"
+
+        run_path = (
+            self.base_path / "derivatives" / self.sub_name / f"{self.pp_run_name}"
         )
+        self.preprocessed_data_path = run_path / "preprocessed"
+
         self._pp_data_attributes_path = (
             self.preprocessed_data_path / utils.canonical_names("preprocessed_yaml")
         )
         self._pp_binary_data_path = self.preprocessed_data_path / "si_recording"
+        self._sync_channel_data_path = run_path / "sync_channel"
 
     def get_sub_folder_path(self) -> Path:
         """

--- a/swc_ephys/examples/example_full_pipeline.py
+++ b/swc_ephys/examples/example_full_pipeline.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         run_names,
         config_name,
         sorter,
-        existing_preprocessed_data="load_if_exists",
+        existing_preprocessed_data="overwrite",
         existing_sorting_output="overwrite",
         overwrite_postprocessing=True,
         slurm_batch=False,

--- a/swc_ephys/pipeline/load_data.py
+++ b/swc_ephys/pipeline/load_data.py
@@ -43,17 +43,24 @@ def load_spikeglx_data(
     """
     preprocess_data = PreprocessingData(base_path, sub_name, run_names)
 
-    all_recordings = [
-        se.read_spikeglx(
-            folder_path=run_path,
-            stream_id="imec0.ap",
-            all_annotations=True,
-            load_sync_channel=False,
-        )
-        for run_path in preprocess_data.all_run_paths
-    ]
+    all_recordings = []
+    all_sync = []
+    for run_path in preprocess_data.all_run_paths:
+        with_sync, without_sync = [
+            se.read_spikeglx(
+                folder_path=run_path,
+                stream_id="imec0.ap",
+                all_annotations=True,
+                load_sync_channel=sync,
+            )
+            for sync in [True, False]
+        ]
+        all_recordings.append(without_sync)
+        sync_channel_id = with_sync.get_channel_ids()[-1]
+        all_sync.append(with_sync.channel_slice(channel_ids=[sync_channel_id]))
 
     preprocess_data["0-raw"] = append_recordings(all_recordings)
+    preprocess_data.sync = append_recordings(all_sync)
 
     return preprocess_data
 


### PR DESCRIPTION
closes #34 

The probe is not loaded in SpikeInterface is sync channel is loaded, so the sync channel does not interfere with sorting.  As such, the sync channel must be handled separately (see the issue).

This PR saves the sync channel to a 'sync_channels' folder at the same folder level as 'preprocessing'.