### PR TITLE
Add `spkyingcircus`, `mountainsort5`, `tridesclous`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "spython",  # I think missing from SI?
     "submitit",
     # sorter-specific
-    "trisdesclous",
+    "tridesclous",
+    "pwd",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "jaxlib",
     "spython",  # I think missing from SI?
     "submitit",
+    # sorter-specific
+    "trisdesclous",
 ]
 
 [project.urls]

--- a/swc_ephys/configs/default.yaml
+++ b/swc_ephys/configs/default.yaml
@@ -21,6 +21,9 @@
   'kilosort3':
     'car': False
     'freq_min': 300
+  'mountainsort5':
+    'scheme': '2'
+    'filter': False
 
 'waveforms':
   'ms_before': 2

--- a/swc_ephys/examples/example_full_pipeline.py
+++ b/swc_ephys/examples/example_full_pipeline.py
@@ -14,7 +14,7 @@ run_names = [
 ]
 
 config_name = "default"
-sorter = "kilosort2_5"  # "spykingcircus"
+sorter = "spykingcircus"  #  "kilosort2_5"  # "spykingcircus" # mountainsort5
 
 if __name__ == "__main__":
     run_full_pipeline(
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         run_names,
         config_name,
         sorter,
-        existing_preprocessed_data="overwrite",
+        existing_preprocessed_data="load_if_exists",
         existing_sorting_output="overwrite",
         overwrite_postprocessing=True,
         slurm_batch=False,

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 import spikeinterface as si
 from spikeinterface import curation
-from spikeinterface.extractors import KiloSortSortingExtractor
+from spikeinterface.extractors import NpzSortingExtractor
 
 from ..configs.configs import get_configs
 from ..data_classes.sorting import SortingData
@@ -261,10 +261,25 @@ def load_sorting_output(sorting_data: SortingData, sorter: str) -> BaseSorting:
 
     recording = sorting_data[sorting_data.init_data_key]
 
-    sorting = KiloSortSortingExtractor(
-        folder_path=sorting_data.sorter_run_output_path,
-        keep_good_only=False,
-    )
+    if "kilosort" in sorter:
+        sorting = si.extractors.read_kilosort(
+            folder_path=sorting_data.sorter_run_output_path,
+            keep_good_only=False,
+        )
+    elif sorter == "mountainsort5":
+        sorting = NpzSortingExtractor(
+            (sorting_data.sorter_run_output_path / "firings.npz").as_posix()
+        )  # si.extractors.read_mda_sorting(file_path=(sorting_data.sorter_run_output_path / "firings.npz").as_posix(), sampling_frequency=sorting_data["0-preprocessed"].get_sampling_frequency())
+
+    elif sorter == "tridesclous":
+        sorting = si.extractors.read_tridesclous(
+            folder_path=sorting_data.sorter_run_output_path.as_posix()
+        )
+
+    elif sorter == "spykingcircus":
+        sorting = si.extractors.read_spykingcircus(
+            folder_path=sorting_data.sorter_run_output_path.as_posix()
+        )
 
     sorting = sorting.remove_empty_units()
     sorting_without_excess_spikes = curation.remove_excess_spikes(sorting, recording)

--- a/swc_ephys/pipeline/postprocess.py
+++ b/swc_ephys/pipeline/postprocess.py
@@ -34,7 +34,6 @@ except ImportError:
     )
     MATRIX_BACKEND = "numpy"
 
-# TODO: delete all quality checks before re-analysis.
 
 # --------------------------------------------------------------------------------------
 # Run Postprocessing
@@ -269,7 +268,7 @@ def load_sorting_output(sorting_data: SortingData, sorter: str) -> BaseSorting:
     elif sorter == "mountainsort5":
         sorting = NpzSortingExtractor(
             (sorting_data.sorter_run_output_path / "firings.npz").as_posix()
-        )  # si.extractors.read_mda_sorting(file_path=(sorting_data.sorter_run_output_path / "firings.npz").as_posix(), sampling_frequency=sorting_data["0-preprocessed"].get_sampling_frequency())
+        )
 
     elif sorter == "tridesclous":
         sorting = si.extractors.read_tridesclous(

--- a/swc_ephys/pipeline/sort.py
+++ b/swc_ephys/pipeline/sort.py
@@ -149,8 +149,18 @@ def validate_inputs(
     """
     assert slurm_batch is False, "SLURM run has slurm_batch set True"
 
-    supported_sorters = ["spykingcircus", "kilosort2", "kilosort2_5", "kilosort3"]
-    assert sorter in supported_sorters, f"sorter must be: {supported_sorters}"
+    supported_sorters = [
+        "kilosort2",
+        "kilosort2_5",
+        "kilosort3",
+        "mountainsort5",
+        "spykingcircus",
+        "tridesclous",
+    ]
+
+    assert (
+        sorter in supported_sorters
+    ), f"sorter {sorter} is invalid, must be one of: {supported_sorters}"
 
     assert (
         utils.check_singularity_install()

--- a/tests/test_integration/test_initial.py
+++ b/tests/test_integration/test_initial.py
@@ -46,8 +46,8 @@ class TestFirstEphys:
 
         yield [output_data_path, sub_name, run_names, output_path]
 
-    #      if output_path.is_dir():
-    #         shutil.rmtree(output_path)
+        if output_path.is_dir():
+            shutil.rmtree(output_path)
 
     def run_full_pipeline(
         self,
@@ -55,7 +55,7 @@ class TestFirstEphys:
         sub_name,
         run_names,
         existing_preprocessed_data="fail_if_exists",
-        existing_sorting_output="overwrite",  # TODO: should use "fail_if_exists"?
+        existing_sorting_output="fail_if_exists",
         slurm_batch=False,
         sorter="kilosort2_5",
     ):
@@ -97,9 +97,16 @@ class TestFirstEphys:
         preprocess_data.save_all_preprocessed_data(overwrite=True)
 
     @pytest.mark.parametrize(
-        "sorter", ["spykingcircus"]
-    )  # ["kilosort2", "kilosort2_5", "kilosort3",
-    #   "mountainsort5", "spykingcircus", "tridesclous"])
+        "sorter",
+        [
+            "kilosort2",
+            "kilosort2_5",
+            "kilosort3",
+            "mountainsort5",
+            "spykingcircus",
+            "tridesclous",
+        ],
+    )
     def test_single_run_local__(self, test_info, sorter):
         test_info.pop(3)
         test_info[2] = test_info[2][0]

--- a/tests/test_integration/test_initial.py
+++ b/tests/test_integration/test_initial.py
@@ -57,13 +57,14 @@ class TestFirstEphys:
         existing_preprocessed_data="fail_if_exists",
         existing_sorting_output="overwrite",
         slurm_batch=False,
+        sorter="kilosort2_5",
     ):
         full_pipeline.run_full_pipeline(
             base_path,
             sub_name,
             run_names,
             config_name="default",
-            sorter="kilosort2_5",
+            sorter=sorter,
             existing_preprocessed_data=existing_preprocessed_data,
             existing_sorting_output=existing_sorting_output,
             overwrite_postprocessing=True,
@@ -95,10 +96,14 @@ class TestFirstEphys:
         preprocess_data = preprocess.preprocess(preprocess_data, pp_steps, verbose=True)
         preprocess_data.save_all_preprocessed_data(overwrite=True)
 
-    def test_single_run_local__(self, test_info):
+    @pytest.mark.parametrize(
+        "sorter", ["spykingcircus"]
+    )  # ["kilosort2", "kilosort2_5", "kilosort3",
+    #   "mountainsort5", "spykingcircus", "tridesclous"])
+    def test_single_run_local__(self, test_info, sorter):
         test_info.pop(3)
         test_info[2] = test_info[2][0]
-        self.run_full_pipeline(*test_info)
+        self.run_full_pipeline(*test_info, sorter=sorter)
 
     def test_single_run_local_overwrite(self, test_info):
         test_info.pop(3)

--- a/tests/test_integration/test_initial.py
+++ b/tests/test_integration/test_initial.py
@@ -46,8 +46,8 @@ class TestFirstEphys:
 
         yield [output_data_path, sub_name, run_names, output_path]
 
-        if output_path.is_dir():
-            shutil.rmtree(output_path)
+    #      if output_path.is_dir():
+    #         shutil.rmtree(output_path)
 
     def run_full_pipeline(
         self,
@@ -55,7 +55,7 @@ class TestFirstEphys:
         sub_name,
         run_names,
         existing_preprocessed_data="fail_if_exists",
-        existing_sorting_output="overwrite",
+        existing_sorting_output="overwrite",  # TODO: should use "fail_if_exists"?
         slurm_batch=False,
         sorter="kilosort2_5",
     ):


### PR DESCRIPTION
Add spkyingcircus, mountainsort5, tridesclous (spikeinterface supporters many more, but this will do for now. While it is expected that most early users will use kilosort, extending support for other sorters is useful because:

- These sorters can be run a) without NVIDIA GPU b) outside of Docker so are useful for testing
- Check the pattern for extending to new sorters. It is quite simple - allow the sorter as an argument and load 'sorter' from the appropriate spikeinterface extractor in `postprocess.py`.
